### PR TITLE
Fix 2019 Top Committer Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Awarded:
 
 ### Top Committer
 
--	[Jordan Liggitt](https://twitter.com/fredbrancz)
+-	[Frederic Branczyk](https://twitter.com/fredbrancz)
 
 ### Chop Wood Carry Water
 


### PR DESCRIPTION
This PR fixes name of the Top Committer, the link is correct but the name is not.

cc @caniszczyk